### PR TITLE
Fix compilation on Bionic

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1,6 +1,7 @@
 #include "server.h"
 
 #include <errno.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <sys/un.h>
 #include <time.h>


### PR DESCRIPTION
The SSIZE_MAX symbol (which is an alias for LONG_MAX) is defined in limits.h.