### PR TITLE
server: Convert `monitor_cb` from prepare handle to `raft_step` callback

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,18 +6,7 @@ on:
 
 jobs:
   build-and-test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-20.04
-          - ubuntu-22.04
-        compiler:
-          - gcc
-          - clang
-        tracing:
-          - LIBCOWSQL_TRACE=1
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4
@@ -27,8 +16,6 @@ jobs:
           sudo apt install -y lcov libsqlite3-dev liblz4-dev libuv1-dev
 
     - name: Build raft
-      env:
-        CC: ${{ matrix.compiler }}
       run: |
           git clone https://github.com/cowsql/raft.git --depth 1
           cd raft
@@ -40,24 +27,17 @@ jobs:
           cd ..
 
     - name: Build cowsql
-      env:
-        CC: ${{ matrix.compiler }}
       run: |
           autoreconf -i
           ./configure --enable-debug --enable-code-coverage --enable-sanitize
           make CFLAGS=-O0 -j2
 
     - name: Test
-      env:
-        CC: ${{ matrix.compiler }}
       run: |
-           export ${{ matrix.tracing }}
            make CFLAGS=-O0 -j2 check || (cat ./test-suite.log && false)
 
     - name: Coverage
-      env:
-        CC: ${{ matrix.compiler }}
-      run: if [ "${CC}" = "gcc" ]; then make code-coverage-capture; fi
+      run: make code-coverage-capture
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/test/lib/server.c
+++ b/test/lib/server.c
@@ -70,7 +70,7 @@ void test_server_start(struct test_server *s, const MunitParameter params[])
 	rv = cowsql_node_set_connect_func(s->cowsql, endpointConnect, s);
 	munit_assert_int(rv, ==, 0);
 
-	rv = cowsql_node_set_network_latency_ms(s->cowsql, 10);
+	rv = cowsql_node_set_network_latency_ms(s->cowsql, 20);
 	munit_assert_int(rv, ==, 0);
 
 	const char *snapshot_threshold_param =


### PR DESCRIPTION
Using a prepare handle is unreliable, since while the process is paused by a Jepsen nemesis there might be a lot of data being received by the kernel in the TCP buffer, and that data will be read eagerly by libuv, so the prepare handle callback will not get a chance to run and detect the leadership lost in a timely manner.