### PR TITLE
leader: Fix double-free in case the apply callback is fired by hand

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -43,6 +43,7 @@ void gateway__leader_close(struct gateway *g, int reason)
 	if (g->req != NULL) {
 		if (g->leader->inflight != NULL) {
 			tracef("finish inflight apply request");
+			g->leader->inflight->canceled = true;
 			struct raft_apply *req = &g->leader->inflight->req;
 			req->cb(req, reason, NULL);
 			assert(g->req == NULL);

--- a/src/leader.h
+++ b/src/leader.h
@@ -29,12 +29,8 @@ struct apply
 	int status;            /* Raft apply result */
 	struct leader *leader; /* Leader connection that triggered the hook */
 	int type;              /* Command type */
-	union {                /* Command-specific data */
-		struct
-		{
-			bool is_commit;
-		} frames;
-	};
+	bool canceled;         /* Request canceled by gateway__leader_close */
+	bool fired;            /* True if the req callback was fired. */
 };
 
 struct leader


### PR DESCRIPTION
The gateway__leader_close functions fires the raft apply callback by hand. In that case we need to be careful to not destroy the request object, because raft will fire the callback again.