### PR TITLE
Fix build failure on x32

### DIFF
--- a/src/client/protocol.c
+++ b/src/client/protocol.c
@@ -139,8 +139,8 @@ static ssize_t doRead(int fd,
 		assert(rv == 0);
 		if (context != NULL) {
 			millis =
-			    (context->deadline.tv_sec - now.tv_sec) * 1000 +
-			    (context->deadline.tv_nsec - now.tv_nsec) / 1000000;
+			    (long)((context->deadline.tv_sec - now.tv_sec) * 1000 +
+			    (context->deadline.tv_nsec - now.tv_nsec) / 1000000);
 			if (millis < 0) {
 				/* poll(2) will block indefinitely if the
 				 * timeout argument is negative, and we don't
@@ -219,8 +219,8 @@ static ssize_t doWrite(int fd,
 		assert(rv == 0);
 		if (context != NULL) {
 			millis =
-			    (context->deadline.tv_sec - now.tv_sec) * 1000 +
-			    (context->deadline.tv_nsec - now.tv_nsec) / 1000000;
+			    (long)((context->deadline.tv_sec - now.tv_sec) * 1000 +
+			    (context->deadline.tv_nsec - now.tv_nsec) / 1000000);
 			if (millis < 0) {
 				/* poll(2) will block indefinitely if the
 				 * timeout argument is negative, and we don't


### PR DESCRIPTION
This applies the patch from dqlite's packaging to fix the build error on x32.