### PR TITLE
leader: Translate RAFT_NOSPACE into SQLITE_IOERR_WRITE

### DIFF
--- a/src/leader.c
+++ b/src/leader.c
@@ -336,6 +336,9 @@ static int leaderApplyFrames(struct exec *req,
 
 	rv = raft_apply(l->raft, &apply->req, &buf, 1, leaderApplyFramesCb);
 	if (rv != 0) {
+		if (rv == RAFT_NOSPACE) {
+			rv = SQLITE_IOERR_WRITE;
+		}
 		tracef("raft apply failed %d", rv);
 		goto err_after_command_encode;
 	}


### PR DESCRIPTION
When raft_apply() returns RAFT_NOSPACE, it's no translated to proper SQLite error.