### PR TITLE
Replace platform-dependent threading and synchronization primitives with libuv

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -31,8 +31,8 @@ struct cowsql_node
 	struct raft_uv_transport raft_transport; /* Raft libuv transport */
 	struct raft_io raft_io;                  /* libuv I/O */
 	struct raft_fsm raft_fsm;                /* cowsql FSM */
-	sem_t ready;                             /* Server is ready */
-	sem_t handover_done;
+	uv_sem_t ready;                          /* Server is ready */
+	uv_sem_t handover_done;
 	queue queue; /* Incoming connections */
 	queue conns; /* Active connections */
 	queue roles_changes;
@@ -70,9 +70,9 @@ struct node_store_cache
 struct cowsql_server
 {
 	/* Threading stuff: */
-	pthread_cond_t cond;
-	pthread_mutex_t mutex;
-	pthread_t refresh_thread;
+	uv_cond_t cond;
+	uv_mutex_t mutex;
+	uv_thread_t refresh_thread;
 
 	/* These fields are protected by the mutex: */
 	bool shutdown;

--- a/src/server.h
+++ b/src/server.h
@@ -32,7 +32,6 @@ struct cowsql_node
 	struct raft_io raft_io;                  /* libuv I/O */
 	struct raft_fsm raft_fsm;                /* cowsql FSM */
 	sem_t ready;                             /* Server is ready */
-	sem_t stopped;                           /* Notify loop stopped */
 	sem_t handover_done;
 	queue queue; /* Incoming connections */
 	queue conns; /* Active connections */


### PR DESCRIPTION
Portability Refactor: 

Following the discussion started in thread https://github.com/cowsql/cowsql/issues/40 and as a first step in the ongoing effort to improve the portability of this project and enable cross-platform support for other operating systems, this PR refactors the code to  replace platform-dependent thread and synchronization primitives (such as pthreads) with the cross-platform synchronization implementations provided by LibUV.

I ran the available tests via `make check` in Linux  aarch64  (Debian 11 container in a MacBook) :
```
PASS: unit-test
PASS: integration-test
============================================================================
Testsuite summary for libcowsql 1.15.9
============================================================================
# TOTAL: 2
# PASS:  2
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
