### PR TITLE
Fix -Wdiscarded-qualifiers warnings when using C23 memchr

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -987,10 +987,10 @@ static const struct client_node_info *findNodeInCache(
  * representation. */
 static int parseNodeStore(char *buf, size_t len, struct node_store_cache *cache)
 {
-	const char *p = buf;
+	char *p = buf;
 	const char *end = buf + len;
 	char *nl;
-	const char *version_str;
+	char *version_str;
 	const char *addr;
 	const char *id_str;
 	const char *dig;
@@ -1126,12 +1126,12 @@ static int parseLocalInfo(char *buf,
 			  char **local_addr,
 			  uint64_t *local_id)
 {
-	const char *p = buf;
+	char *p = buf;
 	const char *end = buf + len;
 	char *nl;
-	const char *version_str;
-	const char *addr;
-	const char *id_str;
+	char *version_str;
+	char *addr;
+	char *id_str;
 	const char *dig;
 	unsigned long long id;
 


### PR DESCRIPTION
The pointers `p`, `version_str`, `addr` and `id_str` are not really const, so remove the const specifier.

Fixes #44.
